### PR TITLE
Fix Prototype Pollution

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ If the property already exists and is not an object, `access.set()` will throw a
 
 If you want to force setting new values on none object value and override it, or to prevent any errors, use `force=true`.
 
+If prototype pollution is attempted, `access.set()` will throw an error whose `code` is `SET_ON_PROTOTYPE`.
+
 Returns `value`
 
 ### access.delete(obj, key_list) : boolean

--- a/index.js
+++ b/index.js
@@ -39,6 +39,16 @@ function access (obj, keys, default_) {
 // @param {Array|string} keys
 function set (obj, keys, value, force) {
   _access(obj, keys, function (parent, current, key, last) {
+
+    // Avoid prototye pollution
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      const err = new Error('refuse to modify prototype')
+      err.code = 'SET_ON_PROTOTYPE'
+      err.keys = keys
+      err.value
+      throw err
+    }
+
     if (last) {
       parent[key] = value
       return true


### PR DESCRIPTION
`object-access` is vulnerable to `Prototype Pollution`.

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as _proto_, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

This package allowing for modification of prototype behavior using a `__proto__` payload, which may result in Information Disclosure/DoS/RCE.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. README updated acordingly.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```js
// poc.js
var objectAccess = require("object-access")
var obj = {}
console.log("Before : " + obj.polluted);
objectAccess.set(obj, '__proto__.polluted', 'Yes! Its Polluted');
var obj1 = {}
console.log("After : " + obj1.polluted);
```

2. Execute the following commands in another terminal:

```bash
npm i object-access # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

After fix execution will trow `Error: refuse to modify prototype` and polluted will be undefined

### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected